### PR TITLE
Improve testing and always grab artifacts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,11 +1,8 @@
 name: Tests
-on:
-  push:
-    branches:
-      - main
+on: push
 
 jobs:
-  # <------------------ TEST BASIC JOB ------------------->
+  # <---------------- TEST BASIC CONFIG ------------------>
   code-quality-basic:
     name: Basic
     runs-on: ubuntu-latest
@@ -16,9 +13,19 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: erzz/codeclimate-standalone
+          ref: ${{ github.ref }}
           path: ./.github/actions/self
       - name: Basic Test
         uses: ./.github/actions/self
+      - name: Upload Reports
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: Basic Reports
+          path: |
+            codeclimate-report.json
+            codeclimate-report.html
+  # <--------------- TEST ADVANCED CONFIG ---------------->
   code-quality-advanced:
     name: Advanced
     runs-on: ubuntu-latest
@@ -29,8 +36,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: erzz/codeclimate-standalone
+          ref: ${{ github.ref }}
           path: ./.github/actions/self
-      - name: Basic Test
+      - name: Advanced Test
         uses: ./.github/actions/self
         with:
           html_report: true
@@ -39,3 +47,11 @@ jobs:
           major_threshold: 1
           critical_threshold: 0
           blocker_threshold: 0
+      - name: Upload Reports
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: Advanced Reports
+          path: |
+            codeclimate-report.json
+            codeclimate-report.html

--- a/README.md
+++ b/README.md
@@ -57,6 +57,21 @@ The default output of this job is the JSON format of the report and it is often 
 
 This report is only available if the input `html_report` is set to true. Useful for a human to read when investigating what the findings were with helpful links and references.
 
+### Collecting artifacts
+
+As with any other artifact - a simple step such as the following would upload both the JSON and HTML (if enabled) artifacts at the end of the job
+
+```yaml
+- name: Upload Reports
+  uses: actions/upload-artifact@v2
+  if: always()
+  with:
+    name: Code Climate Reports
+    path: |
+      codeclimate-report.json
+      codeclimate-report.html
+```
+
 ## Examples
 
 ### Run a default codeclimate scan


### PR DESCRIPTION
Testing was a bit basic and not providing the artifacts to double check everything needed.

closes #5 but its not possible it seems to use a branch based ref for version of the marketplace action - so restricted to treating itself as a repo for now